### PR TITLE
Add Node.js to dependencies in docs

### DIFF
--- a/docs/01-install.md
+++ b/docs/01-install.md
@@ -5,6 +5,7 @@
 System requirements:
 - [Python 3.6](https://www.python.org/downloads/) or newer (I strongly recommend checking "Add Python to PATH" when installing)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- [Node.js](https://nodejs.org/en/download/) and npm
 
 ## Linux
 
@@ -12,6 +13,7 @@ System requirements:
 - Python 3.6 or newer
 - [Docker](https://docs.docker.com/engine/install/)
 - [docker-compose](https://docs.docker.com/compose/install/)
+- [Node.js](https://nodejs.org/en/download/) and npm
 
 ## Running
 
@@ -23,6 +25,8 @@ Now, you can update and start the development server:
 ./bullet.py update
 ./bullet.py start
 ```
+
+You can now visit bullet on http://localhost:8000 or http://math.localhost:8000.
 
 You should run the commands above whenever you pull new commits from our repository.
 


### PR DESCRIPTION
We use node and npm to build CSS, but we don't mention it is required to have them installed in the docs.