### PR TITLE
Fix code mounting in development

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./bullet/:/usr/src/bullet/
+      - ./bullet/:/app/
     depends_on:
       - bullet-db
     command: ./entrypoint.sh


### PR DESCRIPTION
Code is no longer located in `/usr/src/bullet/` after #44, but we did mount local code there in the `docker-compose.yml`. I have updated it to mount code to `/app`, as expected by the runtime.