### PR TITLE
Remove target from docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
   web:
     build:
       context: .
-      target: basebuild
     image: bullet
     env_file:
       - .env


### PR DESCRIPTION
I removed `basebuild` from `Dockerfile`, but I left it in `docker-compose.yaml`, which then fails to build the image.