### PR TITLE
es-registration: allow empty content_blocks

### DIFF
--- a/bullet/competitions/templates/register/details.html
+++ b/bullet/competitions/templates/register/details.html
@@ -1,9 +1,11 @@
 {% extends "register/base.html" %}
+{% load content_blocks %}
 {% load bform %}
 {% load country_url %}
 {% load i18n %}
 
 {% block register_content %}
+    {% load_blocks "register" %}
     {% include "register/partials/category.html" %}
     {% include "register/partials/venue.html" %}
     {% include "register/partials/school.html" %}
@@ -69,6 +71,10 @@
             {% blocktrans trimmed with link=link %}
                 More information on the processing of personal data can be found <a href="{{ link }}">on this page</a>.
             {% endblocktrans %}
+        </div>
+
+        <div class="mb-8 prose max-w-none">
+            {% content_block "register:bottom_text" allow_empty=True %}
         </div>
 
         <button type="submit" class="btn">{% trans "Register" %}</button>

--- a/bullet/web/templatetags/content_blocks.py
+++ b/bullet/web/templatetags/content_blocks.py
@@ -43,7 +43,7 @@ def load_blocks(context, *groups):
 
 
 @register.simple_tag(name="content_block", takes_context=True)
-def content_block(context, combined_ref):
+def content_block(context, combined_ref, allow_empty=False):
     group, ref = combined_ref.split(":", 1)
 
     if "__blocks" not in context:
@@ -72,4 +72,6 @@ def content_block(context, combined_ref):
                 )
             return mark_safe(c)
 
+    if allow_empty:
+        return ""
     return mark_safe(f"<span class='cb-missing'>Missing '{group}:{ref}'</span>")


### PR DESCRIPTION
We should replace the czech MSMT footer with this as well