### PR TITLE
Make competition number nullable

### DIFF
--- a/bullet/competitions/migrations/0026_competition_number_and_more.py
+++ b/bullet/competitions/migrations/0026_competition_number_and_more.py
@@ -12,8 +12,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="competition",
             name="number",
-            field=models.IntegerField(default=1),
-            preserve_default=False,
+            field=models.IntegerField(blank=True, null=True),
         ),
         migrations.AddConstraint(
             model_name="competition",

--- a/bullet/competitions/models/competitions.py
+++ b/bullet/competitions/models/competitions.py
@@ -49,7 +49,9 @@ class CompetitionQuerySet(models.QuerySet):
 class Competition(models.Model):
     name = models.CharField(max_length=128)
     branch = BranchField()
-    number = models.IntegerField()
+    number = models.IntegerField(
+        null=True, blank=True
+    )  # TODO: remove null when migrated on production
 
     web_start = models.DateTimeField()
 


### PR DESCRIPTION
This changes a migration retrospectively.

We can do this because the migration was not yet applied on production database. At the time when I created that migration, there was just one competition per branch. We did not release a new version since then, but now there are multiple competitions.

We could create a `RunPython` migration to assign numbers automatically, but it is a little less painful to add the field, set numbers and later remove null=True. 