### PR TITLE
Fix cross-branch admin competition setting leak

### DIFF
--- a/bullet/bullet_admin/utils.py
+++ b/bullet/bullet_admin/utils.py
@@ -12,13 +12,15 @@ if TYPE_CHECKING:
 
 def get_active_competition(request: HttpRequest):
     if not hasattr(request, "_badmin_competition"):
-        if "badmin_competition" not in request.session:
+        session_key = f"badmin_{request.BRANCH.identifier}_competition"
+        if session_key not in request.session:
             request._badmin_competition = Competition.objects.get_current_competition(
                 request.BRANCH
             )
         else:
+            stored_id = request.session.get(session_key)
             request._badmin_competition = Competition.objects.filter(
-                branch=request.BRANCH, id=request.session.get("badmin_competition")
+                branch=request.BRANCH, id=stored_id
             ).first()
 
     return request._badmin_competition

--- a/bullet/bullet_admin/views/__init__.py
+++ b/bullet/bullet_admin/views/__init__.py
@@ -53,5 +53,7 @@ class CompetitionSwitchView(LoginRequiredMixin, TemplateView):
 
     def post(self, request, *args, **kwargs):
         if "competition" in request.GET:
-            request.session["badmin_competition"] = request.GET.get("competition")
+            request.session[
+                f"badmin_{request.BRANCH.identifier}_competition"
+            ] = request.GET.get("competition")
         return HttpResponseClientRefresh()

--- a/bullet/competitions/views/register.py
+++ b/bullet/competitions/views/register.py
@@ -62,7 +62,8 @@ class RegistrationMixin:
             raise RegistrationError()
 
         cc = Category.objects.filter(
-            id=request.session["register_form"]["category"]
+            id=request.session["register_form"]["category"],
+            competition=self.competition,
         ).first()
 
         if not cc:


### PR DESCRIPTION
I have also fixed category leak in registration. I did not prefix the registration session with branch just because everything in that session is already checked for invalid data (categories from other countries, competitions...) and will reset the form.