### PR TITLE
team-deletion-mail-fix: use pickled team instead of team_id

### DIFF
--- a/bullet/bullet_admin/views/teams.py
+++ b/bullet/bullet_admin/views/teams.py
@@ -254,7 +254,7 @@ class TeamDeleteView(AdminRequiredMixin, DeleteView):
         if not can_access_venue(request, obj.venue):
             return HttpResponseForbidden()
 
-        send_deletion_email.delay(obj.id)
+        send_deletion_email.delay(obj)
         return super().post(request, *args, **kwargs)
 
     def get_success_url(self):

--- a/bullet/users/emails/teams.py
+++ b/bullet/users/emails/teams.py
@@ -55,8 +55,8 @@ def send_to_competition_email(team_id: int):
 
 
 @job
-def send_deletion_email(team_id: int):
-    team = Team.objects.get(id=team_id)
+def send_deletion_email(team: Team):
+    # We must use pickled Team here as the team don't exist in the database
     with TeamCountry(team):
         send_email(
             Branches[team.venue.category.competition.branch],


### PR DESCRIPTION
When sending deletion emails, the team does not exist, so we cannot pass it by using its ID.

We must pass the team object, which will get pickled by RQ.