### PR TITLE
Rewrite waiting list logic to Python

### DIFF
--- a/bullet/bullet_admin/templates/bullet_admin/venues/waiting_list.html
+++ b/bullet/bullet_admin/templates/bullet_admin/venues/waiting_list.html
@@ -65,8 +65,9 @@
                         </td>
                         <td class="p-3 whitespace-nowrap">
                             <div>
-                                Teams from school: <b>{{ team.from_school }}</b>
+                                Teams from school: <b>{{ team.from_school_corrected }}</b>
                             </div>
+                            {% if team.wildcards %}<div class="text-xs text-gray-600">({{ team.from_school }} team{{ team.from_school|pluralize }} - {{ team.wildcards }} wildcard{{ team.wildcards|pluralize }})</div>{% endif %}
                             <div class="text-xs text-gray-600">
                                 {{ team.registered_at|date:"j M Y, H:i" }}
                             </div>

--- a/bullet/competitions/templates/teams/list.html
+++ b/bullet/competitions/templates/teams/list.html
@@ -56,7 +56,7 @@
         <div class="flex flex-col md:flex-row md:items-center px-4 py-2 {% cycle "bg-gray-50" "" %} rounded-md">
             <div class="md:w-1/2 mb-1 md:mb-0">
                 {% if team.school %}
-                <div class="text-primary font-bold text-lg">
+                <div class="text-primary font-bold">
                     {{ team.school.name }}
 
                     {% if team.in_school_symbol %}
@@ -65,10 +65,10 @@
                 </div>
                 <div class="text-sm text-gray-600">{{ team.school.address }}</div>
                 {% else %}
-                <div class="text-primary font-bold text-lg">{{ team.name }}</div>
+                <div class="text-primary font-bold">{{ team.name }}</div>
                 {% endif %}
             </div>
-            <div class="md:w-1/2">
+            <div class="md:w-1/2 text-sm">
                 {{ team.contestants.all|join:", " }}
             </div>
         </div>


### PR DESCRIPTION
As it turns out, all the joins and stuff were actually wrong. This was not spotted previously, as it really broke for schools with more than 5 teams on the waiting list, which is not common.

I tried wrangling the QuerySet, but I was unable to reach the desired state or code cleanness, so I rewrote it in Python for the moment.

This implementation always builds the whole waiting list and filters its results per requested venues. This could be improved upon, but a lot of that is required to have `teams_from_school` count correct in the case of schools with teams in multiple venues. Which was something the old QuerySet failed to do correctly.