### PR TITLE
fix: admin visible competitions

### DIFF
--- a/bullet/competitions/models/competitions.py
+++ b/bullet/competitions/models/competitions.py
@@ -50,7 +50,11 @@ class CompetitionQuerySet(models.QuerySet):
         roles = CompetitionRole.objects.filter(
             user=user, competition__branch=branch
         ).values("competition")
-        return qs.filter(id__in=roles)
+        competitions = roles.union(
+            qs.filter(results_public=True)
+            .values("id")
+        )
+        return qs.filter(id__in=competitions)
 
     def for_photos(self, user: "User", branch: "Branch"):
         """
@@ -68,7 +72,11 @@ class CompetitionQuerySet(models.QuerySet):
         roles = CompetitionRole.objects.filter(
             user=user, competition__branch=branch
         ).values("competition")
-        return qs.filter(id__in=roles)
+        competitions = roles.union(
+            qs.filter(results_public=True)
+            .values("id")
+        )
+        return qs.filter(id__in=competitions)
 
 
 class Competition(models.Model):


### PR DESCRIPTION
Possibly we should discuss, where the methods `for_user` and `for_photos` are being used, since allowing an admin to see photos of ended competition in the public interface is not equivalent to allowing him edit albums in the admin interface. If you are not a branch admin nor photographer, you do not see `Albums` in the admin menu, however, by URL, you can reach the editing webpage.