### PR TITLE
feat: multilingual tearoffs

### DIFF
--- a/bullet/bullet_admin/forms/documents.py
+++ b/bullet/bullet_admin/forms/documents.py
@@ -94,7 +94,6 @@ class TearoffForm(forms.Form):
         required=True,
     )
 
-    # TODO custom validator for this field
     teams_selected = SequenceListField(
         label="Selected teams",
         help_text='Teams to be included in the printed tearoffs. Syntax example: "1-4, 5, 7" (teams with numbers 1 to 4, 5 and 7). Leave empty to include all available teams',
@@ -116,10 +115,9 @@ class TearoffForm(forms.Form):
         label="Backup team language",
     )
 
-    mono_or_bil = forms.ChoiceField(
-        label="Print tearoffs for Monolingual or Bilingual teams",
-        choices=[("mono", "Monolingual"), ("bil", "Bilingual")],
-        help_text="Tearoffs of teams whose language doesn't match primary tearoff language are to be printed separately as a double-sided document.",
+    language_print_options = forms.ChoiceField(
+        label="Language print options",
+        choices=[("mixed", "Mixed"), ("mono", "Monolingual"), ("bil", "Bilingual")],
     )
 
     ordering = forms.ChoiceField(

--- a/bullet/bullet_admin/forms/documents.py
+++ b/bullet/bullet_admin/forms/documents.py
@@ -90,7 +90,7 @@ class SequenceListField(forms.CharField):
 
 class TearoffForm(forms.Form):
     primary_tearoff_language = forms.ChoiceField(
-        label="Primary language of the Venue",
+        label="Primary venue language",
         required=True,
     )
 
@@ -107,7 +107,7 @@ class TearoffForm(forms.Form):
         min_value=1,
     )
     backup_teams = forms.IntegerField(
-        label="Number of Backup teams",
+        label="Number of backup teams",
         initial=0,
         min_value=0,
     )

--- a/bullet/bullet_admin/forms/documents.py
+++ b/bullet/bullet_admin/forms/documents.py
@@ -89,11 +89,6 @@ class SequenceListField(forms.CharField):
 
 
 class TearoffForm(forms.Form):
-    primary_tearoff_language = forms.ChoiceField(
-        label="Primary venue language",
-        required=True,
-    )
-
     teams_selected = SequenceListField(
         label="Selected teams",
         help_text='Teams to be included in the printed tearoffs. Syntax example: "1-4, 5, 7" (teams with numbers 1 to 4, 5 and 7). Leave empty to include all available teams',
@@ -113,6 +108,11 @@ class TearoffForm(forms.Form):
     )
     backup_team_language = forms.ChoiceField(
         label="Backup team language",
+    )
+
+    primary_tearoff_language = forms.ChoiceField(
+        label="Primary venue language",
+        required=True,
     )
 
     language_print_options = forms.ChoiceField(
@@ -135,8 +135,6 @@ class TearoffForm(forms.Form):
         accepted_languages = list(
             filter(lambda lang: lang[0] in venue.accepted_languages, settings.LANGUAGES)
         )
-        self.fields["primary_tearoff_language"].choices = [
-            ("", "---------")
-        ] + accepted_languages
+        self.fields["primary_tearoff_language"].choices = accepted_languages
         self.fields["backup_team_language"].choices = accepted_languages
         self._problem_count = problems

--- a/bullet/bullet_admin/forms/documents.py
+++ b/bullet/bullet_admin/forms/documents.py
@@ -50,19 +50,38 @@ class CertificateForm(forms.Form):
 
 
 class TearoffForm(forms.Form):
+    primary_tearoff_language = forms.ChoiceField(
+        label="Primary language of the Venue",
+        required=True,
+    )
+
+    # TODO custom validator for this field
+    teams_selected = forms.CharField(
+        label="Selected teams",
+        help_text="Empty for all, seq 1-4 etc.",
+        required=False,
+    )
+
     first_problem = forms.IntegerField(
         label="First problem",
         initial=1,
         min_value=1,
     )
     backup_teams = forms.IntegerField(
-        label="Number of backup teams",
+        label="Number of Backup teams",
         initial=0,
         min_value=0,
     )
     backup_team_language = forms.ChoiceField(
         label="Backup team language",
     )
+
+    mono_or_bil = forms.ChoiceField(
+        label="Print tearoffs for Monolingual or Bilingual teams",
+        choices=[("mono", "Monolingual"), ("bil", "Bilingual")],
+        help_text="Tearoffs of teams whose language doesn't match primary tearoff language are to be printed separately as a double-sided document.",
+    )
+
     ordering = forms.ChoiceField(
         label="Problem ordering",
         choices=[("align", "Aligned"), ("seq", "Sequential")],
@@ -75,7 +94,11 @@ class TearoffForm(forms.Form):
         super().__init__(**kwargs)
 
         self.fields["first_problem"].initial = first_problem
-        self.fields["backup_team_language"].choices = list(
+        accepted_languages = list(
             filter(lambda lang: lang[0] in venue.accepted_languages, settings.LANGUAGES)
         )
+        self.fields["primary_tearoff_language"].choices = [
+            ("", "---------")
+        ] + accepted_languages
+        self.fields["backup_team_language"].choices = accepted_languages
         self._problem_count = problems

--- a/bullet/bullet_admin/forms/documents.py
+++ b/bullet/bullet_admin/forms/documents.py
@@ -49,6 +49,45 @@ class CertificateForm(forms.Form):
         return self.cleaned_data
 
 
+class SequenceListField(forms.CharField):
+    def __init__(self, *args, min_value=None, max_value=None, **kwargs):
+        self.min_value = 0 if min_value is None else min_value
+        self.max_value = 999 if max_value is None else max_value
+        super().__init__(*args, **kwargs)
+
+    def clean(self, value):
+        vals = super().clean(value).strip(",").strip()
+        result_set = set()
+        if len(vals) == 0:
+            return set()
+
+        for val in vals.split(","):
+            numbers = []
+            parts = val.split("-")
+            if len(parts) > 2:
+                raise ValidationError("Invalid sequence: " + f"'{val}'")
+
+            try:
+                for x in parts:
+                    num = int(x)
+                    if num > self.max_value:
+                        raise ValidationError("Number too large: " + x)
+                    if num < self.min_value:
+                        raise ValueError
+                    numbers.append(num)
+            except ValueError:
+                raise ValidationError("Invalid input: " + f"'{val}'")
+
+            if len(numbers) == 1:
+                result_set.add(numbers[0])
+            elif len(numbers) == 2:
+                if numbers[0] > numbers[1]:
+                    raise ValidationError("Invalid sequence: " + f"'{val}'")
+                result_set.update(range(numbers[0], numbers[1] + 1))
+
+        return result_set
+
+
 class TearoffForm(forms.Form):
     primary_tearoff_language = forms.ChoiceField(
         label="Primary language of the Venue",
@@ -56,10 +95,11 @@ class TearoffForm(forms.Form):
     )
 
     # TODO custom validator for this field
-    teams_selected = forms.CharField(
+    teams_selected = SequenceListField(
         label="Selected teams",
-        help_text="Empty for all, seq 1-4 etc.",
+        help_text='Teams to be included in the printed tearoffs. Syntax example: "1-4, 5, 7" (teams with numbers 1 to 4, 5 and 7). Leave empty to include all available teams',
         required=False,
+        max_length=500,
     )
 
     first_problem = forms.IntegerField(

--- a/bullet/bullet_admin/templates/bullet_admin/competition/tearoff.html
+++ b/bullet/bullet_admin/templates/bullet_admin/competition/tearoff.html
@@ -1,10 +1,18 @@
 {% extends "bullet_admin/generic/form.html" %}
 
 {% block before_form %}
-<p class="mb-4">Current uploaded tearoff files:
-{% for lang in available_langs %}
-    <a href = "{% url 'badmin:competition_upload_tearoffs_file' tearoff_filename=lang %}">
-        {{ lang }}</a>{% if not forloop.last %}, {% endif %}
-{% endfor %}
-</p>
+  <p class="mb-2">Current uploaded tearoff files:</p>
+
+  {% if available_files %}
+    <ul class="mb-4">
+      {% for file in available_files %}
+        <li>
+          <a class="link" href="{% url 'badmin:competition_upload_tearoffs_file' tearoff_filename=file.name %}">{{ file.name }}</a>
+          ({{ file.modified_time|date:"d.m.Y H:i:s" }})
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p class="mb-4">No tearoff files uploaded.</p>
+  {% endif %}
 {% endblock before_form %}

--- a/bullet/bullet_admin/templates/bullet_admin/venues/tearoffs.html
+++ b/bullet/bullet_admin/templates/bullet_admin/venues/tearoffs.html
@@ -14,5 +14,18 @@
                 <b>Sequential:</b> Problems are sorted sequentially on the page, meaning you will need to order them manually. For example, you will get a page containing problems 1–4 for the first team, then another page containing problems 5–8, and so on.
             </li>
         </ul>
+
+        <p class="mb-2">There are three language print options:</p>
+        <ul class="list-disc list-outside ml-6">
+            <li>
+                <b>Mixed:</b> Will print tear-offs for all teams. The language of the problems is derived from the team's specified language.
+            </li>
+            <li>
+                <b>Monolingual:</b> Only prints tear-offs for teams whose specified language matches the primary venue language.
+            </li>
+            <li>
+                <b>Bilingual:</b> Returns a double-sided document with primary venue language on one side and team's specified language on the other. Only prints teams whose specified language differs from primary venue language.
+            </li>
+        </ul>
     </div>
 {% endblock before_form %}

--- a/bullet/bullet_admin/views/competition.py
+++ b/bullet/bullet_admin/views/competition.py
@@ -1,6 +1,5 @@
 import os.path
 import zipfile
-from operator import itemgetter
 
 from competitions.models import Competition
 from django.conf import settings
@@ -132,44 +131,67 @@ class CompetitionTearoffUploadView(PermissionCheckMixin, GenericForm, FormView):
         ctx = super().get_context_data(**kwargs)
         path = self.get_upload_folder()
         if not default_storage.exists(path):
-            ctx["available_langs"] = []
+            files = []
         else:
-            ctx["available_langs"] = default_storage.listdir(path)[1]
+            files = default_storage.listdir(path)[1]
+
+        ctx["available_files"] = [
+            {
+                "name": file,
+                "modified_time": default_storage.get_modified_time(
+                    os.path.join(path, file)
+                ),
+            }
+            for file in sorted(files)
+        ]
         return ctx
 
     def is_valid_name(self, name):
-        return name in map(itemgetter(0), settings.LANGUAGES)
+        return name in {code for code, _ in settings.LANGUAGES}
 
     def upload_zip(self, problems):
         target_dir = default_storage.path(self.get_upload_folder())
+        invalid_files = []
+        uploaded_files = []
 
         with zipfile.ZipFile(problems) as zipf:
             for file in zipf.namelist():
                 name, extension = os.path.splitext(file)
-                if extension != ".pdf":
+                if extension.lower() != ".pdf":
                     continue
 
                 if not self.is_valid_name(name):
+                    invalid_files.append(file)
                     continue
 
                 zipf.extract(file, target_dir)
+                uploaded_files.append(file)
+
+        return invalid_files, uploaded_files
 
     def upload_pdf(self, problems):
-        name, extension = os.path.splitext(problems.name)
+        name, _ = os.path.splitext(problems.name)
         if not self.is_valid_name(name):
-            return
+            return [problems.name], []
         path = os.path.join(self.get_upload_folder(), problems.name)
         if default_storage.exists(path):
             default_storage.delete(path)
         default_storage.save(path, problems)
+        return [], [problems.name]
 
     def form_valid(self, form):
         problems = form.cleaned_data["problems"]
 
-        if problems.name.endswith(".zip"):
-            self.upload_zip(problems)
+        if problems.name.lower().endswith(".zip"):
+            invalid_files, uploaded_files = self.upload_zip(problems)
         else:
-            self.upload_pdf(problems)
+            invalid_files, uploaded_files = self.upload_pdf(problems)
 
-        messages.success(self.request, "Tearoffs uploaded successfully.")
+        if invalid_files:
+            messages.error(
+                self.request,
+                "Invalid tearoff file names: " + ", ".join(invalid_files),
+            )
+        if uploaded_files:
+            messages.success(self.request, "Tearoffs uploaded successfully.")
         return redirect("badmin:competition_upload_tearoffs")

--- a/bullet/bullet_admin/views/venues.py
+++ b/bullet/bullet_admin/views/venues.py
@@ -270,15 +270,31 @@ class TearoffView(VenueMixin, GenericForm, FormView):
             tearoff_dir = Path(
                 default_storage.path(competition.secret_dir / "tearoffs")
             )
-            t = TearoffGenerator(tearoff_dir, form.cleaned_data["backup_team_language"])
+            t = TearoffGenerator(
+                tearoff_dir, form.cleaned_data["primary_tearoff_language"]
+            )
         except TearoffRequirementMissingError as e:
             return HttpResponse(str(e), status=500)
 
-        teams = list(
-            Team.objects.competing()
-            .filter(venue=self.venue, number__isnull=False)
-            .all()
-        )
+        # if len (form.cleaned_data["teams_selected"]) != 0:
+
+        if form.cleaned_data["mono_or_bil"] == "mono":
+            teams = list(
+                Team.objects.competing()
+                .filter(
+                    venue=self.venue,
+                    number__isnull=False,
+                    language=form.cleaned_data["primary_tearoff_language"],
+                )
+                .all()
+            )
+        else:
+            teams = list(
+                Team.objects.competing()
+                .filter(venue=self.venue, number__isnull=False)
+                .exclude(language=form.cleaned_data["primary_tearoff_language"])
+                .all()
+            )
 
         for i in range(form.cleaned_data["backup_teams"]):
             teams.append(
@@ -291,13 +307,24 @@ class TearoffView(VenueMixin, GenericForm, FormView):
             )
 
         try:
-            data = t.generate_pdf(
-                teams,
-                form.cleaned_data["first_problem"],
-                form._problem_count,
-                form.cleaned_data["ordering"],
-                form.cleaned_data["include_qr_codes"],
-            )
+            if form.cleaned_data["mono_or_bil"] == "mono":
+                data = t.generate_pdf(
+                    teams,
+                    form.cleaned_data["first_problem"],
+                    form._problem_count,
+                    form.cleaned_data["ordering"],
+                    True,
+                    form.cleaned_data["include_qr_codes"],
+                )
+            else:
+                data = t.generate_bilingual_pdf(
+                    teams,
+                    form.cleaned_data["first_problem"],
+                    form._problem_count,
+                    form.cleaned_data["ordering"],
+                    form.cleaned_data["include_qr_codes"],
+                )
+
             return FileResponse(data, filename="tearoffs.pdf")
         except TearoffRequirementMissingError as e:
             return HttpResponse(str(e), status=500)

--- a/bullet/bullet_admin/views/venues.py
+++ b/bullet/bullet_admin/views/venues.py
@@ -286,11 +286,11 @@ class TearoffView(VenueMixin, GenericForm, FormView):
                 number__in=form.cleaned_data["teams_selected"]
             )
 
-        if form.cleaned_data["mono_or_bil"] == "mono":
+        if form.cleaned_data["language_print_options"] == "mono":
             team_query = team_query.filter(
                 language=form.cleaned_data["primary_tearoff_language"]
             ).all()
-        else:
+        elif form.cleaned_data["language_print_options"] == "bil":
             team_query = team_query.exclude(
                 language=form.cleaned_data["primary_tearoff_language"]
             ).all()
@@ -308,21 +308,21 @@ class TearoffView(VenueMixin, GenericForm, FormView):
             )
 
         try:
-            if form.cleaned_data["mono_or_bil"] == "mono":
+            if form.cleaned_data["language_print_options"] == "bil":
+                data = t.generate_bilingual_pdf(
+                    teams,
+                    form.cleaned_data["first_problem"],
+                    form._problem_count,
+                    form.cleaned_data["ordering"],
+                    form.cleaned_data["include_qr_codes"],
+                )
+            else:
                 data = t.generate_pdf(
                     teams,
                     form.cleaned_data["first_problem"],
                     form._problem_count,
                     form.cleaned_data["ordering"],
                     False,
-                    form.cleaned_data["include_qr_codes"],
-                )
-            else:
-                data = t.generate_bilingual_pdf(
-                    teams,
-                    form.cleaned_data["first_problem"],
-                    form._problem_count,
-                    form.cleaned_data["ordering"],
                     form.cleaned_data["include_qr_codes"],
                 )
 

--- a/bullet/bullet_admin/views/venues.py
+++ b/bullet/bullet_admin/views/venues.py
@@ -276,25 +276,26 @@ class TearoffView(VenueMixin, GenericForm, FormView):
         except TearoffRequirementMissingError as e:
             return HttpResponse(str(e), status=500)
 
-        # if len (form.cleaned_data["teams_selected"]) != 0:
+        team_query = Team.objects.competing().filter(
+            venue=self.venue, number__isnull=False
+        )
+
+        #   Selected teams
+        if len(form.cleaned_data["teams_selected"]) != 0:
+            team_query = team_query.filter(
+                number__in=form.cleaned_data["teams_selected"]
+            )
 
         if form.cleaned_data["mono_or_bil"] == "mono":
-            teams = list(
-                Team.objects.competing()
-                .filter(
-                    venue=self.venue,
-                    number__isnull=False,
-                    language=form.cleaned_data["primary_tearoff_language"],
-                )
-                .all()
-            )
+            team_query = team_query.filter(
+                language=form.cleaned_data["primary_tearoff_language"]
+            ).all()
         else:
-            teams = list(
-                Team.objects.competing()
-                .filter(venue=self.venue, number__isnull=False)
-                .exclude(language=form.cleaned_data["primary_tearoff_language"])
-                .all()
-            )
+            team_query = team_query.exclude(
+                language=form.cleaned_data["primary_tearoff_language"]
+            ).all()
+
+        teams = list(team_query)
 
         for i in range(form.cleaned_data["backup_teams"]):
             teams.append(
@@ -313,7 +314,7 @@ class TearoffView(VenueMixin, GenericForm, FormView):
                     form.cleaned_data["first_problem"],
                     form._problem_count,
                     form.cleaned_data["ordering"],
-                    True,
+                    False,
                     form.cleaned_data["include_qr_codes"],
                 )
             else:

--- a/bullet/documents/generators/tearoff.py
+++ b/bullet/documents/generators/tearoff.py
@@ -31,6 +31,7 @@ class TearoffGenerator:
     def __init__(self, problem_pdf_root: Path, primary_language: str):
         self._problem_pdfs = {}
         self.problem_pdf_root = problem_pdf_root
+        self.primary_language = primary_language
         statement_height = float(
             self.get_problem_pdf(primary_language).pages[0].trimbox[3]
         )
@@ -59,20 +60,24 @@ class TearoffGenerator:
     def close_problem_pdfs(self):
         for pdf in self._problem_pdfs.values():
             pdf.close()
+        self._problem_pdfs = {}
+
+    def check_requirement_for_language(self, language, problem_count: int):
+        try:
+            problem_pdf = self.get_problem_pdf(language)
+        except TearoffRequirementMissingError:
+            raise
+
+        if len(problem_pdf.pages) != problem_count + 1:
+            raise TearoffRequirementMissingError(
+                f"Wrong page count for language {language}: expected "
+                f"{problem_count + 1}, got {len(problem_pdf.pages)}."
+            )
 
     def check_requirements(self, teams: Sequence[Team], problem_count: int):
         languages = set(map(attrgetter("language"), teams))
         for language in languages:
-            try:
-                problem_pdf = self.get_problem_pdf(language)
-            except TearoffRequirementMissingError:
-                raise
-
-            if len(problem_pdf.pages) != problem_count + 1:
-                raise TearoffRequirementMissingError(
-                    f"Wrong page count for language {language}: expected "
-                    f"{problem_count + 1}, got {len(problem_pdf.pages)}."
-                )
+            self.check_requirement_for_language(language, problem_count)
 
     def sequential_tearoffs(
         self, teams: Sequence[Team], problem_count: int, offset: int
@@ -110,10 +115,13 @@ class TearoffGenerator:
         first_problem: int,
         problem_count: int,
         ordering: str,
+        target_lang: bool,  # If true, will generate all Tearoffs in primary_language, instead of particular team's language
         include_qr: bool = True,
     ) -> BinaryIO:
-        self.check_requirements(teams, problem_count)
-
+        if not target_lang:
+            self.check_requirements(teams, problem_count)
+        else:
+            self.check_requirement_for_language(self.primary_language, problem_count)
         offset = first_problem - 1
         problem_count -= offset
 
@@ -123,10 +131,44 @@ class TearoffGenerator:
         if ordering == "align":
             tearoffs = self.aligned_tearoffs(teams, problem_count, offset)
 
-        return self.generate_tearoffs(tearoffs, include_qr)
+        return self.generate_tearoffs(tearoffs, include_qr, target_lang)
+
+    def generate_bilingual_pdf(
+        self,
+        teams: Sequence[Team],
+        first_problem: int,
+        problem_count: int,
+        ordering: str,
+        include_qr: bool = True,
+    ):
+        primary_language_io = self.generate_pdf(
+            teams, first_problem, problem_count, ordering, True, include_qr
+        )
+        secondary_language_io = self.generate_pdf(
+            teams, first_problem, problem_count, ordering, False, include_qr
+        )
+
+        with (
+            Pdf.open(primary_language_io) as primary_pdf,
+            Pdf.open(secondary_language_io) as secondary_pdf,
+        ):
+            result = Pdf.new()
+
+            for i in range(len(primary_pdf.pages)):
+                result.pages.append(primary_pdf.pages[i])
+                result.pages.append(secondary_pdf.pages[i])
+
+            output = io.BytesIO()
+            result.save(output)
+
+        output.seek(0)
+        return output
 
     def generate_tearoffs(
-        self, tearoffs: Sequence[Tearoff | None], include_qr: bool
+        self,
+        tearoffs: Sequence[Tearoff | None],
+        include_qr: bool,
+        target_lang: bool,
     ) -> BinaryIO:
         output_stream = io.BytesIO()
         canvas = Canvas(output_stream)
@@ -140,7 +182,7 @@ class TearoffGenerator:
 
         pdf = Pdf.open(output_stream)
         for i, page in enumerate(pages):
-            self.add_statements_to_page(pdf.pages[i], page)
+            self.add_statements_to_page(pdf.pages[i], page, target_lang)
 
         final_stream = io.BytesIO()
         pdf.save(final_stream)
@@ -254,11 +296,16 @@ class TearoffGenerator:
 
         canvas.restoreState()
 
-    def add_statements_to_page(self, page: Page, tearoffs: Iterable[Tearoff | None]):
+    def add_statements_to_page(
+        self, page: Page, tearoffs: Iterable[Tearoff | None], target_lang: bool
+    ):
+        language = self.primary_language
         for i, tearoff in enumerate(tearoffs):
             if tearoff is None:
                 continue
-            pdf_file = self.get_problem_pdf(tearoff.team.language)
+            if not target_lang:
+                language = tearoff.team.language
+            pdf_file = self.get_problem_pdf(language)
             page.add_underlay(
                 pdf_file.pages[tearoff.page_number],
                 Rectangle(


### PR DESCRIPTION
fixes https://github.com/naboj-org/bullet/issues/1082

Specifically, I remade the tearoff generating form, as to print monolingual tearoffs (of teams whose language matches the primary venue language) and bilingual tearoffs (of teams whose language doesn't match the primary venue language) seperately. The bilingual tearoffs are printed as double-sided documents: on one side, the language of the venue, on the other: the language of the team in question.